### PR TITLE
Detect system arch to download/install correct version for host

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,7 @@ install_yq() {
   local binary_path="$bin_install_path/yq"
   local download_url
 
-  platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  platform="$(uname | tr '[:upper:]' '[:lower:]')_$(getArch)"
   download_url="$(get_download_url "${version}" "${platform}")"
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"
@@ -20,6 +20,18 @@ install_yq() {
   chmod +x "${binary_path}"
 }
 
+getArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    armv*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+  esac
+  echo "$ARCH"
+}
 
 get_filename() {
   local platform="$1"


### PR DESCRIPTION
Hey @SuperQ I thought i'd piggy back on your PR to fix the versioning on this asdf package, since the original owner is taking so long to merge your PR. I have confirmed this works:

```bash
$ uname -m
aarch64

$ asdf plugin add yq https://github.com/mathew-fleisch/asdf-yq.git

$ asdf install yq latest
Creating bin directory
Downloading yq from https://github.com/mikefarah/yq/releases/download/v4.12.1/yq_linux_arm64 to /root/.asdf/installs/yq/4.12.1/bin/yq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   620  100   620    0     0   2254      0 --:--:-- --:--:-- --:--:--  2254
100 7643k  100 7643k    0     0  6758k      0  0:00:01  0:00:01 --:--:-- 12.9M

$ asdf global yq latest

$ yq --version
yq (https://github.com/mikefarah/yq/) version 4.12.1
```

I have done this modification to a few asdf plugins as I like to use it on raspberry pis. Here is an example:
https://github.com/Antiarchitect/asdf-helm/pull/4/files